### PR TITLE
fix(api): Correct route order to fix model loading

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -25,20 +25,6 @@ if (process.env.NODE_ENV !== 'production') {
   debugLogger(app);
 }
 
-// Route static assets
-app.get('*', async (c) => {
-  const { pathname } = new URL(c.req.url);
-  
-  // Only handle static assets for non-API paths
-  if (pathname.startsWith('/api/')) {
-    // Finalize context for API paths to avoid context errors
-    return await c.notFound();
-  }
-  
-  // Handle static assets with the ASSETS binding
-  return c.env.ASSETS.fetch(c.req.raw);
-});
-
 // Mount API routes
 app.route('/api/models', modelsRouter);
 app.post('/api/chat', async (c) => {
@@ -53,6 +39,20 @@ app.post('/api/chat', async (c) => {
 app.route('/api/prompts', promptsRouter);
 app.route('/api/mcp-servers', mcpServersRouter);
 app.route('/api', fileRouter);
+
+// Route static assets
+app.get('*', async (c) => {
+  const { pathname } = new URL(c.req.url);
+
+  // Only handle static assets for non-API paths
+  if (pathname.startsWith('/api/')) {
+    // Finalize context for API paths to avoid context errors
+    return await c.notFound();
+  }
+
+  // Handle static assets with the ASSETS binding
+  return c.env.ASSETS.fetch(c.req.raw);
+});
 
 // Not found handler
 app.notFound((c) => {


### PR DESCRIPTION
The static asset middleware was incorrectly placed before the API routes, causing all GET requests to API endpoints to return a 404 Not Found error. This prevented the frontend from fetching the list of available models.

This change moves the static asset middleware to be after the API routes, ensuring that API requests are correctly handled.